### PR TITLE
New argument for pulling specific post view stats

### DIFF
--- a/system/helpers.php
+++ b/system/helpers.php
@@ -6,6 +6,7 @@ function wmp_get_popular( $args = array() ) {
 	$limit = 5;
 	$post_type = array( 'post' );
 	$range = 'all_time';
+	$post_id = null;
 	
 	if ( isset( $args['limit'] ) ) {
 		$limit = $args['limit'];
@@ -41,23 +42,39 @@ function wmp_get_popular( $args = array() ) {
 			break;
 	}
 
-	$holder = implode( ',', array_fill( 0, count( $post_type ), '%s') );
-	
-	$sql = "
-		SELECT
-			p.*
-		FROM
-			{$wpdb->prefix}most_popular mp
-			INNER JOIN {$wpdb->prefix}posts p ON mp.post_id = p.ID
-		WHERE
-			p.post_type IN ( $holder ) AND
-			p.post_status = 'publish'
-		{$order}
-		LIMIT %d
-	";
+	if ( isset( $args['post_id'] ) ) {
+		// take the user away from the main query to pull data from a specific post
+		$sql = "
+			SELECT
+				p.*
+			FROM
+				{$wpdb->prefix}most_popular mp
+			WHERE
+				p.post_id = '" . $args['post_id'] . "'
+			LIMIT 1
+		";
 
-	$result = $wpdb->get_results( $wpdb->prepare( $sql, array_merge( $post_type, array( $limit ) ) ), OBJECT );
-	
+		$result = $wpdb->get_results( $wpdb->prepare( $sql ) );
+
+	} else {
+
+		$holder = implode( ',', array_fill( 0, count( $post_type ), '%s') );
+		
+		$sql = "
+			SELECT
+				p.*
+			FROM
+				{$wpdb->prefix}most_popular mp
+				INNER JOIN {$wpdb->prefix}posts p ON mp.post_id = p.ID
+			WHERE
+				p.post_type IN ( $holder ) AND
+				p.post_status = 'publish'
+			{$order}
+			LIMIT %d
+		";
+
+		$result = $wpdb->get_results( $wpdb->prepare( $sql, array_merge( $post_type, array( $limit ) ) ), OBJECT );
+	}
 	if ( ! $result) {
 		return array();
 	}

--- a/system/helpers.php
+++ b/system/helpers.php
@@ -6,7 +6,6 @@ function wmp_get_popular( $args = array() ) {
 	$limit = 5;
 	$post_type = array( 'post' );
 	$range = 'all_time';
-	$post_id = null;
 	
 	if ( isset( $args['limit'] ) ) {
 		$limit = $args['limit'];
@@ -46,11 +45,11 @@ function wmp_get_popular( $args = array() ) {
 		// take the user away from the main query to pull data from a specific post
 		$sql = "
 			SELECT
-				p.*
+				1_day_stats, 7_day_stats, 30_day_stats, all_time_stats
 			FROM
 				{$wpdb->prefix}most_popular mp
 			WHERE
-				p.post_id = '" . $args['post_id'] . "'
+				mp.post_id = '$args[post_id]'
 			LIMIT 1
 		";
 


### PR DESCRIPTION
I wrote a conditional inside the wmp_get_popular() function to accept an argument that is a post ID. This allows the user to access the view count the plugin is keeping track of for a specific post. The returned object is the 4 view count statistics in the database table. 

I don't know if this fits in with the theme of the plugin per se, but I wanted to put all the good view count data to use.
