### PR TITLE
Add class to widget's UL for easier CSS

### DIFF
--- a/system/widget.php
+++ b/system/widget.php
@@ -89,7 +89,7 @@ class WMP_Widget extends WP_Widget {
 		// Display the widget
 		echo $before_widget;
 		if ( $defaults['title'] ) echo $before_title . $defaults['title'] . $after_title;
-		echo '<ul>';
+		echo '<ul class="wp-most-popular">';
 		global $post;
 		foreach ( $posts as $post ):
 			setup_postdata( $post );


### PR DESCRIPTION
To allow this widget to be styled differently than other widgets it needs a class attribute to identify it with CSS. The idea came from WordPress's own [recent-comments widget](https://github.com/WordPress/WordPress/blob/master/wp-includes/default-widgets.php#L692), which has a UL element with an id attribute: recentcomments. This is obviously most useful if there are styles you want to apply to only this widget and not the others.

**This commit adds the "wp-most-popular" class to the UL element.**

No class is added to the LI elements because they can be selected as children of the UL element in the style sheet. This is the same as my previous pull-request except the class is wp-most-popular instead of most-popular.
